### PR TITLE
Disallow empty commits

### DIFF
--- a/cmd/run.go
+++ b/cmd/run.go
@@ -69,7 +69,10 @@ then stage files interactively with git "add --patch".`,
 		// Commit
 		for _, repoName := range config.Repos {
 			if doCommit || doPush || doPR {
-				shared.Commit(repoName, config.CommitMsg)
+				err := shared.Commit(repoName, config.CommitMsg)
+				if _, ok := err.(*shared.NoChangesError); ok {
+					continue
+				}
 			}
 			if doPush || doPR {
 				shared.Push(repoName, config.BranchName, false)

--- a/shared/commit.go
+++ b/shared/commit.go
@@ -9,10 +9,15 @@ import (
 	"github.com/go-git/go-git/v5"
 )
 
-// If there are staged files, commits them to the
-// currently active branch. Does nothing if there
-// are no staged files
-func Commit(repoName string, commitMsg string) {
+type NoChangesError struct{}
+
+func (e *NoChangesError) Error() string {
+	return fmt.Sprintln("No staged files changes in worktree.")
+}
+
+// Commits the staged changes in a repo. Returns NoChangesError
+// if there are no staged changes in the repo.
+func Commit(repoName string, commitMsg string) error {
 	reposDir := "repos"
 	cwd, _ := os.Getwd()
 	repoDir := path.Join(cwd, reposDir, repoName)
@@ -40,9 +45,10 @@ func Commit(repoName string, commitMsg string) {
 	}
 
 	if !hasStagedChanges {
-		fmt.Printf("No staged changes in %s repo. Skipping...\n", repoName)
-		return
+		fmt.Printf("No staged changes in %s repo. Skipping commit.\n", repoName)
+		return &NoChangesError{}
 	}
 
 	gitTree.Commit(commitMsg, &git.CommitOptions{})
+	return nil
 }


### PR DESCRIPTION
This PR makes the `commit` command return a `NoChangesError` if there are no staged changes in the repo in which it's run. This error can be used to prevent the `run` command from continuing to push a branch and open PRs in repos when no changes exist.