### PR TITLE
Log repo name to console during git add

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,6 @@ Use `rrr -h` or `rrr <command> -h` for more info and available flags
 
 ## To Do:
 
-- [ ] Add repo names when doing `git add` during `rrr run`
 - [ ] Parallelize cloning of repos (go routine?)
 - [ ] Use oauth for GitHub authentication
 - [ ] Unit tests

--- a/cmd/run.go
+++ b/cmd/run.go
@@ -1,6 +1,7 @@
 package cmd
 
 import (
+	"fmt"
 	"log"
 	"os"
 	"os/exec"
@@ -57,6 +58,12 @@ then stage files interactively with git "add --patch".`,
 				addFlag = "-i"
 			} else if addAll {
 				addFlag = "-A"
+			}
+
+			if addFlag == "-A" {
+				fmt.Printf("Staged all changes for \u001b[32;1m%s\u001b[0m.\n", repoName)
+			} else {
+				fmt.Printf("\n\nChanges for \u001b[32;1m%s\u001b[0m:\n", repoName)
 			}
 			gitAddCmd := exec.Command("git", "add", addFlag)
 			gitAddCmd.Stdout = os.Stdout

--- a/shared/push.go
+++ b/shared/push.go
@@ -29,7 +29,7 @@ func Push(repoName string, headBranchName string, deleteBranch bool) {
 			RefSpecs: []gitConfig.RefSpec{gitConfig.RefSpec(":refs/heads/" + headBranchName)},
 		})
 		if err == git.NoErrAlreadyUpToDate {
-			fmt.Printf("No \"%s\" branch to delete. Skipping...\n", headBranchName)
+			fmt.Printf("No \"%s\" branch to delete in repo \"%s\". Skipping...\n", headBranchName, repoName)
 			return
 		}
 		if err != nil {


### PR DESCRIPTION
This PR updates the logging or `rrr` so that the repo name is shown on the console during the `git add` operation (see screenshots below).


![image](https://user-images.githubusercontent.com/7400326/118839656-ab16c980-b894-11eb-8b74-a1a4d039b579.png)


![image](https://user-images.githubusercontent.com/7400326/118839709-b669f500-b894-11eb-9d7d-35fce2d3c6de.png)
