### PR TITLE
Add delay before applying labels to PR

### DIFF
--- a/shared/pr.go
+++ b/shared/pr.go
@@ -3,6 +3,7 @@ package shared
 import (
 	"fmt"
 	"log"
+	"time"
 
 	"github.com/google/go-github/v34/github"
 	"github.com/spf13/viper"
@@ -32,6 +33,8 @@ func PR(repoName string, repoOwner string, title string, draft bool, baseBranch 
 	if err != nil {
 		log.Fatalf("could not create PR: %v", err)
 	}
+
+	time.Sleep(1 * time.Second)
 
 	_, _, err = client.Issues.AddLabelsToIssue(ctx, repoOwner, repoName, pr.GetNumber(), labels)
 	if err != nil {


### PR DESCRIPTION
This PR adds an arbitrary 1 second delay between when a PR is opened and when the labels are applied. This helps avoid race conditions with the RAPIDS `Label Checker` since both `pull_request.opened` and `pull_request.labeled` events trigger the checker.