### PR TITLE
Parallelize Clones

### DIFF
--- a/shared/clone.go
+++ b/shared/clone.go
@@ -35,12 +35,12 @@ func Clone(repoName string, baseBranchName string, headBranchName string) {
 	reposDir := "repos"
 	cwd, _ := os.Getwd()
 	repoDir := path.Join(cwd, reposDir, repoName)
+	fmt.Printf("Cloning %s\n", repoName)
 
 	if !dirExists(repoDir) {
 		createFork(repoName)
 		gitRepo, err = git.PlainClone(repoDir, false, &git.CloneOptions{
 			ReferenceName: plumbing.ReferenceName(fmt.Sprintf("refs/heads/%s", baseBranchName)),
-			Progress:      os.Stdout,
 			URL:           fmt.Sprintf("git@github.com:rapidsai/%v.git", repoName),
 			RemoteName:    "upstream",
 		})

--- a/shared/config.go
+++ b/shared/config.go
@@ -7,6 +7,8 @@ import (
 	"gopkg.in/yaml.v2"
 )
 
+const ConcurrentClones int = 3
+
 func ReadConfig() (config ConfigInterface) {
 	ymlBytes, err := ioutil.ReadFile("config.yaml")
 	if err != nil {

--- a/shared/files.go
+++ b/shared/files.go
@@ -7,7 +7,7 @@ const Script = `#!/bin/bash
 # This script will be executed in each repo
 
 # Update the changelog of each repo
-echo "rrr is great!" > CHANGELOG.md
+echo "rrr is great!" >> CHANGELOG.md
 `
 
 type ConfigInterface struct {

--- a/shared/model.go
+++ b/shared/model.go
@@ -1,0 +1,6 @@
+package shared
+
+type CloneJob struct {
+	RepoName      string
+	NewBranchName string
+}


### PR DESCRIPTION
This PR enables repos to be cloned in parallel by utilizing worker pools.

[src 1](https://hackernoon.com/concurrency-in-golang-and-workerpool-part-1-e9n31ao)
[src 2](https://gobyexample.com/worker-pools)